### PR TITLE
Updated type of file set in media_content_id for playing response

### DIFF
--- a/custom_components/stream_assist/core/__init__.py
+++ b/custom_components/stream_assist/core/__init__.py
@@ -129,7 +129,7 @@ async def assist_run(
         elif event.type == PipelineEventType.TTS_END:
             if player_entity_id:
                 tts = event.data["tts_output"]
-                play_media(hass, player_entity_id, tts["url"], tts["mime_type"])
+                play_media(hass, player_entity_id, tts["media_id"], tts["mime_type"])
 
         if event_callback:
             event_callback(event)


### PR DESCRIPTION
If I try use Apple HomePod mini they completely not work when we use `url` key with mp3 file path. When I updated this configuration to use `media_id` then it start working. 
```
[homeassistant.components.apple_tv.media_player] Media streaming is not possible with current configuration
```
I think this change should work on other devices as well. If this is a problem, it would be great to add an additional configuration allowing you to choose what file is sent to the audio device to play the sound.