### PR TITLE
Accept all media types

### DIFF
--- a/custom_components/stream_assist/config_flow.py
+++ b/custom_components/stream_assist/config_flow.py
@@ -79,6 +79,7 @@ class OptionsFlowHandler(OptionsFlow):
                     vol.Optional("player_entity_id"): cv.multi_select(players),
                     vol.Optional("stt_start_media"): str,
                     vol.Optional("pipeline_id"): vol.In(pipelines),
+                    vol.Optional("allow_all_mediatypes"): bool,
                 },
                 defaults,
             ),

--- a/custom_components/stream_assist/core/__init__.py
+++ b/custom_components/stream_assist/core/__init__.py
@@ -67,6 +67,8 @@ async def stream_run(hass: HomeAssistant, data: dict, stt_stream: Stream) -> Non
             stream_kwargs["file"] = await get_stream_source(hass, entity)
         else:
             return
+    if "allow_all_mediatypes" not in stream_kwargs:
+        stream_kwargs["allow_all_mediatypes"] = data.get("allow_all_mediatypes", False)
 
     stt_stream.open(**stream_kwargs)
 

--- a/custom_components/stream_assist/core/stream.py
+++ b/custom_components/stream_assist/core/stream.py
@@ -27,7 +27,6 @@ class Stream:
 
             if file.startswith("rtsp"):
                 kwargs["options"]["rtsp_flags"] = "prefer_tcp"
-                kwargs["options"]["allowed_media_types"] = "audio"
 
         kwargs.setdefault("timeout", 5)
 

--- a/custom_components/stream_assist/services.yaml
+++ b/custom_components/stream_assist/services.yaml
@@ -52,3 +52,9 @@ run:
       description: Advanced parameters
       selector:
         object:
+
+    allow_all_mediatypes:
+      name: Allow all media types
+      description: Activate if RTSP camera doesn't support filtering media types
+      selector:
+        boolean:

--- a/custom_components/stream_assist/translations/en.json
+++ b/custom_components/stream_assist/translations/en.json
@@ -21,7 +21,8 @@
           "camera_entity_id": "Camera Entity",
           "player_entity_id": "Player Entity",
           "stt_start_media": "STT start media",
-          "pipeline_id": "Pipeline (Settings > Voice Assistant)"
+          "pipeline_id": "Pipeline (Settings > Voice Assistant)",
+          "allow_all_mediatypes": "Allow all Media Types"
         }
       }
     }


### PR DESCRIPTION
Fixes an issue with some cameras that don't allow media types of type **audio**.
I've tried it on my Sricam camera.