### PR TITLE
Correct 2024.5 warning and error

### DIFF
--- a/custom_components/stream_assist/__init__.py
+++ b/custom_components/stream_assist/__init__.py
@@ -2,9 +2,9 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, ServiceResponse, SupportsResponse
+from homeassistant.core import HomeAssistant, ServiceResponse, SupportsResponse, ServiceCall
 from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.typing import ConfigType, ServiceCallType
+from homeassistant.helpers.typing import ConfigType
 
 from .core import DOMAIN, get_stream_source, assist_run, stream_run
 from .core.stream import Stream
@@ -15,7 +15,7 @@ PLATFORMS = (Platform.SENSOR, Platform.SWITCH)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType):
-    async def run(call: ServiceCallType) -> ServiceResponse:
+    async def run(call: ServiceCall) -> ServiceResponse:
         stt_stream = Stream()
 
         try:

--- a/custom_components/stream_assist/sensor.py
+++ b/custom_components/stream_assist/sensor.py
@@ -44,4 +44,4 @@ class StreamAssistSensor(SensorEntity):
     def signal(self, value: str, extra: dict = None):
         self._attr_native_value = value or STATE_IDLE
         self._attr_extra_state_attributes = extra
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()


### PR DESCRIPTION
As of HA 2024.5, the following two issues appear in the Home Assistant log:

WARNING (ImportExecutor_0) [homeassistant.helpers.typing] ServiceCallType was used from stream_assist, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.ServiceCall instead, please report it to the author of the 'stream_assist' custom integration

RuntimeError: Detected that custom integration 'stream_assist' calls async_write_ha_state from a thread at custom_components/stream_assist/sensor.py, line 47: self.async_write_ha_state(). Please report it to the author of the 'stream_assist' custom integration.

This PR updates these two items to the latest standard.